### PR TITLE
Add bouncing Yamato hyperlink feature

### DIFF
--- a/calculate.py
+++ b/calculate.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+import sys
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: python calculate.py <x> <y>")
+        print("Calculates: x / (y * 1.07 + y * 0.18)")
+        sys.exit(1)
+    
+    try:
+        x = float(sys.argv[1])
+        y = float(sys.argv[2])
+        
+        result = x / (y * 1.07 + y * 0.18)
+        print(result)
+        
+    except ValueError:
+        print("Error: Please provide valid floating point numbers")
+        sys.exit(1)
+    except ZeroDivisionError:
+        print("Error: Division by zero")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/index.html
+++ b/index.html
@@ -362,11 +362,28 @@
                 font-size: 1.3em;
             }
         }
+
+        /* Bouncing Yamato styles */
+        .bouncing-yamato {
+            position: fixed;
+            font-size: 3em;
+            font-weight: bold;
+            color: #0066cc;
+            text-decoration: underline;
+            cursor: pointer;
+            z-index: 2000;
+            user-select: none;
+            white-space: nowrap;
+        }
+
+        .bouncing-yamato:hover {
+            color: #0052a3;
+        }
     </style>
 </head>
 <body>
     <div class="container">
-        <h1>How many Yamatos?</h1>
+        <h1>How many <span id="yamato-trigger" style="color: #0066cc; text-decoration: underline; cursor: pointer;">Yamato</span>s?</h1>
         
         <p style="font-size: 1.5em;">your bank balance:</p>
         
@@ -1488,6 +1505,105 @@
         };
         
         console.log("Run testScenarios() in the console to verify pricing logic");
+
+        // Bouncing Yamato functionality
+        let bouncingYamato = null;
+        let isBouncingActive = false;
+        let animationFrameId = null;
+
+        // Physics properties
+        let position = { x: 0, y: 0 };
+        let velocity = { x: 3, y: 2 };
+        let elementSize = { width: 0, height: 0 };
+
+        function createBouncingYamato() {
+            if (isBouncingActive) return; // Prevent multiple instances
+
+            isBouncingActive = true;
+            bouncingYamato = document.createElement('a');
+            bouncingYamato.href = 'http://yamato02116.com/';
+            bouncingYamato.target = '_blank';
+            bouncingYamato.textContent = 'Yamato';
+            bouncingYamato.className = 'bouncing-yamato';
+            
+            // Start position at center of viewport
+            position.x = window.innerWidth / 2;
+            position.y = window.innerHeight / 2;
+            
+            bouncingYamato.style.left = position.x + 'px';
+            bouncingYamato.style.top = position.y + 'px';
+            
+            document.body.appendChild(bouncingYamato);
+            
+            // Get element dimensions after adding to DOM
+            const rect = bouncingYamato.getBoundingClientRect();
+            elementSize.width = rect.width;
+            elementSize.height = rect.height;
+            
+            // Add click handler to cleanup
+            bouncingYamato.addEventListener('click', cleanupBouncingYamato);
+            
+            // Start animation
+            animateBouncingYamato();
+        }
+
+        function animateBouncingYamato() {
+            if (!isBouncingActive || !bouncingYamato) return;
+
+            // Update position
+            position.x += velocity.x;
+            position.y += velocity.y;
+
+            // Bounce off edges
+            if (position.x <= 0 || position.x + elementSize.width >= window.innerWidth) {
+                velocity.x = -velocity.x;
+                position.x = Math.max(0, Math.min(position.x, window.innerWidth - elementSize.width));
+            }
+
+            if (position.y <= 0 || position.y + elementSize.height >= window.innerHeight) {
+                velocity.y = -velocity.y;
+                position.y = Math.max(0, Math.min(position.y, window.innerHeight - elementSize.height));
+            }
+
+            // Apply position
+            bouncingYamato.style.left = position.x + 'px';
+            bouncingYamato.style.top = position.y + 'px';
+
+            // Continue animation
+            animationFrameId = requestAnimationFrame(animateBouncingYamato);
+        }
+
+        function cleanupBouncingYamato() {
+            if (!isBouncingActive) return;
+
+            isBouncingActive = false;
+            
+            if (animationFrameId) {
+                cancelAnimationFrame(animationFrameId);
+                animationFrameId = null;
+            }
+            
+            if (bouncingYamato && bouncingYamato.parentNode) {
+                bouncingYamato.parentNode.removeChild(bouncingYamato);
+            }
+            
+            bouncingYamato = null;
+        }
+
+        // Add click handler to the trigger element
+        document.getElementById('yamato-trigger').addEventListener('click', function(e) {
+            e.preventDefault();
+            createBouncingYamato();
+        });
+
+        // Handle window resize to update viewport boundaries
+        window.addEventListener('resize', function() {
+            if (isBouncingActive && bouncingYamato) {
+                // Ensure bouncing element stays within new viewport
+                position.x = Math.min(position.x, window.innerWidth - elementSize.width);
+                position.y = Math.min(position.y, window.innerHeight - elementSize.height);
+            }
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Transform "Yamato" text in header into deceptive clickable element
- Spawn bouncing "Yamato" hyperlink that moves across viewport
- Implement physics-based edge collision detection with consistent bouncing
- Link directs to yamato02116.com when successfully clicked
- Add cleanup logic to remove bouncing element after interaction

## Test plan
- [ ] Click "Yamato" in header to spawn bouncing element
- [ ] Verify bouncing element moves continuously and bounces off all viewport edges
- [ ] Test clicking bouncing element opens yamato02116.com in new tab
- [ ] Verify bouncing element is removed after successful click
- [ ] Test viewport resize handling maintains bouncing boundaries
- [ ] Confirm no multiple instances can be spawned simultaneously

🤖 Generated with [Claude Code](https://claude.ai/code)